### PR TITLE
feat(providers): implement the ogr "read-in" provider

### DIFF
--- a/harvester/__init__.py
+++ b/harvester/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """IAFF Harvester."""
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/harvester/load/mongo.py
+++ b/harvester/load/mongo.py
@@ -19,7 +19,7 @@ class GEOJSONLoader(object):
 
         def format_upstream(work, feature):
             return ('{0}/query?objectIds={1}&outFields=*&returnGeometry=true&outSR=4326&f=pjson'
-                    .format(work.layer, feature['properties'].get('OBJECTID')))
+                    .format(work.layer, feature['properties'].get(work.id_field)))
 
         with pymongo.MongoClient(settings.MONGO_CONNECTION) as client:
             db = client[settings.MONGO_DATABASE]
@@ -41,7 +41,8 @@ class GEOJSONLoader(object):
                        'feature': f}
                 _fix_keys(f['properties'])
                 # TODO: Make this query unique across BOTH OBJECTID AND meta.layer!
-                bulk.find({'feature.properties.OBJECTID': f['properties']['OBJECTID'], 'meta.layer': work.layer}).upsert().replace_one(ins)
+                bulk.find({'feature.properties.OBJECTID': f['properties'][work.id_field], 'meta.layer': work.layer}) \
+                    .upsert().replace_one(ins)
 
             bulk.execute()
             dest.create_index([('feature.geometry', pymongo.GEOSPHERE)])

--- a/harvester/providers/readin.py
+++ b/harvester/providers/readin.py
@@ -1,0 +1,93 @@
+from __future__ import absolute_import
+
+import logging
+import mimetypes
+import os
+
+from harvester.http import CachableHTTPHarvester
+from celery.utils.log import get_task_logger
+
+log = get_task_logger(__name__)
+
+
+class ImproperlyConfigured(Exception):
+    pass
+
+
+class ReadInSource(CachableHTTPHarvester):
+    """
+    Implements https://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip.
+    """
+    SUPPORTED_COMPRESSION_TYPES = 'gzip zip tar'.split()
+
+    def __init__(self, url, sr=4246, compression_type=None, *args, **kwargs):
+        super(ReadInSource, self).__init__(*args, **kwargs)
+        self.url = url
+        self.sr = sr
+        self.compression_type = compression_type or self.guess_compression()
+
+        if self.compression_type and self.compression_type not in self.SUPPORTED_COMPRESSION_TYPES:
+            raise ImproperlyConfigured('Compression type {0} is not supported.'.format(self.compression_type))
+
+    def extract(self, work):
+        """
+        Extraction is handled in the transform step.
+        """
+        raise NotImplementedError
+
+    def guess_compression(self):
+        """
+        Uses the mimetype builtin to guess the compression.
+        """
+        mime_type, subtype = mimetypes.guess_type(self.url)
+
+        if mime_type == 'application/zip':
+            return 'zip'
+
+        if mime_type == 'application/x-tar':
+            if subtype == 'gzip':
+                return 'gzip'
+
+            if subtype is None:
+                return 'tar'
+
+    @property
+    def remote_file(self):
+        """
+        Returns True if the file is a remote file, false if its local.
+        """
+        return self.url.startswith('http') or self.url.startswith('ftp')
+
+    def vsi_string(self):
+        """
+        Returns the correct VSI string (https://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip) based on certain
+        conditions.
+        """
+        vsi_string = ''
+
+        if self.compression_type:
+            vsi_string = '/vsi{0}/'.format(self.compression_type)
+
+        if self.remote_file:
+            vsi_string += '/vsicurl/'
+
+        return vsi_string.replace('//', '/')
+
+    def load_to(self, cls, work):
+        return cls.load(self.local_file, work)
+
+    def in_srs_string(self):
+        if self.sr:
+            return '-s_srs {0}'.format(self.sr)
+        return ''
+
+    def transform(self, work):
+        logging.info('Transforming {0} to geojson'.format(self.url))
+
+        self.sr = getattr(work, 'srs', None)
+        self.local_file = os.path.join(self.data_dir, os.path.splitext(os.path.split(self.url)[1])[0] + '.geojson')
+
+        command = 'ogr2ogr -t_srs EPSG:4326 {3} -f "GeoJSON" {0} {1}{2}'.format(self.local_file, self.vsi_string(),
+                                                                                self.url, self.in_srs_string())
+        logging.debug('ReadIn provider gdal command: {0}'.format(command))
+        os.system(command)

--- a/harvester/work-template.json
+++ b/harvester/work-template.json
@@ -8,6 +8,7 @@
     "starting_chunk_size": 1000,
     "min_id": null,
     "max_id": null,
+    "id_field": "OBJECTID",
     "load_destination": "parcels",
     "load_provider": "harvester.load.mongo.GEOJSONLoader",
     "extract_only": false,

--- a/harvester/work.py
+++ b/harvester/work.py
@@ -35,6 +35,8 @@ class Runner(object):
             "city": None,
             "stateco_fips": None,
             "starting_chunk_size": None,
+            "id_field": "OBJECTID",
+            "srs": None,
             "min_id": None,
             "max_id": None,
             "load_destination": None,
@@ -49,6 +51,7 @@ class Runner(object):
         self._provider = None
         self._load_provider = None
         self.validate()
+        self.count = 0
 
     def merge(self, settings):
         def munge_from_json_key(s):
@@ -104,6 +107,14 @@ class Runner(object):
         return self._content.get('state_province')
 
     @property
+    def srs(self):
+        return self._content.get('srs')
+
+    @property
+    def id_field(self):
+        return self._content.get('id_field')
+
+    @property
     def city(self):
         return self._content.get('city')
 
@@ -151,7 +162,10 @@ class Runner(object):
     def do(self):
         try:
             self.started_at = datetime.now()
-            self.count = sum(self.do_extraction().apply().get())
+            try:
+                self.count = sum(self.do_extraction().apply().get())
+            except NotImplementedError:
+                pass
             if not self.extract_only:
                 self.do_transform()
                 self.load_to(self.load_provider)

--- a/tests/test_readin_provider.py
+++ b/tests/test_readin_provider.py
@@ -1,0 +1,41 @@
+import unittest
+from harvester.providers.readin import ReadInSource, ImproperlyConfigured
+from tests import TEST_DIR
+import os
+
+
+class TestReadInSourceHarvesting(unittest.TestCase):
+
+    def test_curl_zip(self):
+        harvester = ReadInSource('http://svn.osgeo.org/gdal/trunk/autotest/ogr/data/poly.zip', data_dir=TEST_DIR)
+
+        self.assertTrue(harvester.remote_file)
+        self.assertTrue('/vsizip/vsicurl/' in harvester.vsi_string())
+        harvester.transform(work=None)
+        self.assertTrue(os.path.exists(os.path.join(TEST_DIR, 'poly.geojson')))
+        self.assertEqual(harvester.local_file, os.path.join(TEST_DIR, 'poly.geojson'))
+
+    def test_local_zip(self):
+        harvester = ReadInSource('poly.zip', data_dir=TEST_DIR)
+        self.assertFalse(harvester.remote_file)
+        self.assertFalse('/vsicurl/' in harvester.vsi_string())
+
+    def test_compression_type(self):
+        harvester = ReadInSource('poly.zip', data_dir=TEST_DIR)
+        self.assertTrue(harvester.guess_compression(), 'zip')
+        self.assertTrue('/vsizip/' in harvester.vsi_string())
+
+        harvester = ReadInSource('poly.tar', data_dir=TEST_DIR)
+        self.assertTrue(harvester.guess_compression(), 'tar')
+        self.assertTrue('/vsitar/' in harvester.vsi_string())
+
+        harvester = ReadInSource('poly.tar.gz', data_dir=TEST_DIR)
+        self.assertTrue(harvester.guess_compression(), 'gzip')
+        self.assertTrue('/vsigzip/' in harvester.vsi_string())
+
+        harvester = ReadInSource('poly.shp', data_dir=TEST_DIR)
+        self.assertIsNone(harvester.guess_compression())
+        self.assertEqual(harvester.vsi_string(), '')
+
+        with self.assertRaises(ImproperlyConfigured):
+            ReadInSource('poly.tar', data_dir=TEST_DIR, compression_type='wtf')


### PR DESCRIPTION
Allows the harvester to ingest extract and transform data in a single step using the GDAL ReadIn functionality (https://trac.osgeo.org/gdal/wiki/UserDocs/ReadInZip).
- Note: Requires GDAL >= 1.6.0.
